### PR TITLE
Make name consistent in metadata

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -108,12 +108,13 @@ impl DescriptorEncoder<'_> {
         help: &str,
         unit: Option<&'s Unit>,
         metric_type: MetricType,
+        auto_suffix: bool,
     ) -> Result<MetricEncoder<'s>, std::fmt::Error> {
         for_both_mut!(
             self,
             DescriptorEncoderInner,
             e,
-            Ok(e.encode_descriptor(name, help, unit, metric_type)?.into())
+            Ok(e.encode_descriptor(name, help, unit, metric_type, auto_suffix)?.into())
         )
     }
 }

--- a/src/encoding/protobuf.rs
+++ b/src/encoding/protobuf.rs
@@ -98,6 +98,7 @@ impl DescriptorEncoder<'_> {
         help: &str,
         unit: Option<&Unit>,
         metric_type: MetricType,
+        auto_suffix: bool,
     ) -> Result<MetricEncoder<'s>, std::fmt::Error> {
         let family = openmetrics_data_model::MetricFamily {
             name: {
@@ -135,6 +136,7 @@ impl DescriptorEncoder<'_> {
                 .metrics,
             metric_type,
             labels,
+            auto_suffix,
         })
     }
 }
@@ -150,6 +152,7 @@ pub(crate) struct MetricEncoder<'f> {
     family: &'f mut Vec<openmetrics_data_model::Metric>,
     /// Labels to be added to each metric.
     labels: Vec<openmetrics_data_model::Label>,
+    auto_suffix: bool,
 }
 
 impl MetricEncoder<'_> {
@@ -245,6 +248,7 @@ impl MetricEncoder<'_> {
             metric_type: self.metric_type,
             family: self.family,
             labels,
+            auto_suffix: self.auto_suffix,
         })
     }
 

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -221,6 +221,7 @@ impl DescriptorEncoder<'_> {
         help: &str,
         unit: Option<&'s Unit>,
         metric_type: MetricType,
+        auto_suffix: bool,
     ) -> Result<MetricEncoder<'s>, std::fmt::Error> {
         self.writer.write_str("# HELP ")?;
         if let Some(prefix) = self.prefix {
@@ -231,7 +232,10 @@ impl DescriptorEncoder<'_> {
         if let Some(unit) = unit {
             self.writer.write_str("_")?;
             self.writer.write_str(unit.as_str())?;
+        } else if metric_type == MetricType::Counter && auto_suffix {
+            self.writer.write_str("_total")?;
         }
+
         self.writer.write_str(" ")?;
         self.writer.write_str(help)?;
         self.writer.write_str("\n")?;
@@ -245,7 +249,10 @@ impl DescriptorEncoder<'_> {
         if let Some(unit) = unit {
             self.writer.write_str("_")?;
             self.writer.write_str(unit.as_str())?;
+        } else if metric_type == MetricType::Counter && auto_suffix {
+            self.writer.write_str("_total")?;
         }
+
         self.writer.write_str(" ")?;
         self.writer.write_str(metric_type.as_str())?;
         self.writer.write_str("\n")?;
@@ -271,6 +278,7 @@ impl DescriptorEncoder<'_> {
             unit,
             const_labels: self.labels,
             family_labels: None,
+            auto_suffix,
         })
     }
 }
@@ -291,6 +299,7 @@ pub(crate) struct MetricEncoder<'a> {
     unit: Option<&'a Unit>,
     const_labels: &'a [(Cow<'static, str>, Cow<'static, str>)],
     family_labels: Option<&'a dyn super::EncodeLabelSet>,
+    auto_suffix: bool,
 }
 
 impl std::fmt::Debug for MetricEncoder<'_> {
@@ -307,6 +316,7 @@ impl std::fmt::Debug for MetricEncoder<'_> {
             .field("unit", &self.unit)
             .field("const_labels", &self.const_labels)
             .field("labels", &labels.as_str())
+            .field("auto_suffix", &self.auto_suffix)
             .finish()
     }
 }
@@ -323,7 +333,9 @@ impl MetricEncoder<'_> {
     ) -> Result<(), std::fmt::Error> {
         self.write_prefix_name_unit()?;
 
-        self.write_suffix("total")?;
+        if self.auto_suffix {
+            self.write_suffix("total")?;
+        }
 
         self.encode_labels::<NoLabelSet>(None)?;
 
@@ -393,6 +405,7 @@ impl MetricEncoder<'_> {
             unit: self.unit,
             const_labels: self.const_labels,
             family_labels: Some(label_set),
+            auto_suffix: self.auto_suffix,
         })
     }
 
@@ -1082,6 +1095,7 @@ mod tests {
                     "some help",
                     None,
                     counter.metric_type(),
+                    false,
                 )?;
                 counter.encode(metric_encoder)?;
                 Ok(())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -14,7 +14,7 @@ pub trait TypedMetric {
 }
 
 /// OpenMetrics metric type.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[allow(missing_docs)]
 pub enum MetricType {
     Counter,


### PR DESCRIPTION
When generating `# Help` and `# Type` metadata be sure to update the name to include the `_total` suffix if the type is a counter.